### PR TITLE
Release new creek-decode-symphonia version

### DIFF
--- a/decode_symphonia/Cargo.toml
+++ b/decode_symphonia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek-decode-symphonia"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
To include the updated `symphonia = "0.5"` dependency

Sorry for the drive-by pull request. We are investigating if creek could be used as a decoding backend over at 
https://github.com/orottier/web-audio-api-rs/pull/168

To avoid duplicated dependencies, we could use a new release.
If I read https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html correct, the main Cargo.toml does not need updating, it will pick up the new version right away