### PR TITLE
do not specify versions for crates in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -54,9 +54,9 @@ decode-all = [
 encode-wav = ["creek-encode-wav"]
 
 [dependencies]
-creek-core = { version = "0.1", path = "core" }
-creek-decode-symphonia = { version = "0.1.0", path = "decode_symphonia", optional = true }
-creek-encode-wav = { version = "0.1.0", path = "encode_wav", optional = true }
+creek-core = { path = "core" }
+creek-decode-symphonia = { path = "decode_symphonia", optional = true }
+creek-encode-wav = { path = "encode_wav", optional = true }
 
 # Unoptimized builds result in prominent gaps of silence after cache misses in the demo player.
 [profile.dev]

--- a/decode_symphonia/Cargo.toml
+++ b/decode_symphonia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek-decode-symphonia"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ repository = "https://github.com/RustyDAW/creek"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-creek-core = { version = "0.1", path = "../core" }
+creek-core = { path = "../core" }
 symphonia = "0.5"
 
 [dev-dependencies]

--- a/encode_wav/Cargo.toml
+++ b/encode_wav/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek-encode-wav"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -13,5 +13,5 @@ repository = "https://github.com/RustyDAW/creek"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-creek-core = { version = "0.1", path = "../core" }
+creek-core = { path = "../core" }
 byte-slice-cast = "1.0.0"


### PR DESCRIPTION
Specifying versions for crates within the workspace requires that
the versions are updated in reverse dependencies when a version
number is increased. This is not a problem if the versions are not
specified and the crates simply refer to other crates' relative
paths within the workspace.