### PR TITLE
bump creek's required version of creek-decode-symphonia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -55,7 +55,7 @@ encode-wav = ["creek-encode-wav"]
 
 [dependencies]
 creek-core = { version = "0.1", path = "core" }
-creek-decode-symphonia = { version = "0.1.0", path = "decode_symphonia", optional = true }
+creek-decode-symphonia = { version = "0.1.1", path = "decode_symphonia", optional = true }
 creek-encode-wav = { version = "0.1.0", path = "encode_wav", optional = true }
 
 # Unoptimized builds result in prominent gaps of silence after cache misses in the demo player.


### PR DESCRIPTION
Without this, `cargo update` in downstream crates doesn't
update to creek-decode-symphonia 0.1.1.