### PR TITLE
Add metadata to Symphonia

### DIFF
--- a/core/src/read/read_stream.rs
+++ b/core/src/read/read_stream.rs
@@ -92,8 +92,7 @@ impl<D: Decoder> ReadDiskStream<D> {
             RingBuffer::<ServerToClientMsg<D>>::new(msg_channel_size);
 
         // Create dedicated close signal.
-        let (close_signal_tx, close_signal_rx) =
-            RingBuffer::<Option<HeapData<D::T>>>::new(1);
+        let (close_signal_tx, close_signal_rx) = RingBuffer::<Option<HeapData<D::T>>>::new(1);
 
         let file: PathBuf = file.into();
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+max_width = 100
+imports_granularity = "Preserve"
+tab_spaces = 4


### PR DESCRIPTION
Turns `<SymphoniaDecoder as Decoder>::FileParams` into a struct containing both the original `SymphoniaDecoderInfo` and a `Metadata` field.

It does appear to work in my dev environment. (I'm writing a music player to replace Strawberry.)

(I have also added a `rustfmt.toml` just because my formatting settings messed a bunch of stuff up)