### PR TITLE
Prepare new releases: creek 1.1.0 and creek-decode-symphonia 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Version History
+
+## Version 1.1.0 (2023-07-11)
+
+- Added the ability to decode MP4/AAC/ALAC files
+- Changed `println` statements to actual `log` entries in `creek-decode-symphonia`
+- Updated Minimum Supported Rust Version (MSRV) from 1.56 to 1.62
+- Updated to Rust edition 2021
+
+## Version 1.0 (2023-06-08)
+
+- Added metadata to `SymphoniaDecoder`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -58,7 +58,7 @@ encode-wav = ["creek-encode-wav"]
 
 [dependencies]
 creek-core = { version = "0.1", path = "core" }
-creek-decode-symphonia = { version = "0.1.1", path = "decode_symphonia", optional = true }
+creek-decode-symphonia = { version = "0.2.0", path = "decode_symphonia", optional = true }
 creek-encode-wav = { version = "0.1.0", path = "encode_wav", optional = true }
 
 # Unoptimized builds result in prominent gaps of silence after cache misses in the demo player.

--- a/decode_symphonia/Cargo.toml
+++ b/decode_symphonia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek-decode-symphonia"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
creek-decode-symphonia 0.2.0 is considered 'breaking' because we're still in the 0.* space, but I think it is warranted (added dependency)