### PR TITLE
Document conventions for working with Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,10 @@ and waiting for the CI results:
 ```sh
 pre-commit run --all-files
 ```
+
+### Git
+
+Conventions for working with Git:
+
+- Commits should follow the [seven rules](https://cbea.ms/git-commit/#seven-rules).
+- Versions are tagged with the prefix `v` followed by the crate's version number to match those displayed on the [crates.io](https://crates.io/crates/creek) page.


### PR DESCRIPTION
@orottier I suggest tagging versions with the prefix `v` as explained in the README.