### PR TITLE
fix bugs, improve performance, update readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -10,13 +10,7 @@ description = "Realtime-safe disk streaming to/from audio files"
 documentation = "https://docs.rs/creek"
 repository = "https://github.com/MeadowlarkDAW/creek"
 readme = "README.md"
-include = [
-    "src/",
-    "COPYRIGHT",
-    "LICENSE-APACHE",
-    "LICENSE-MIT",
-    "how_it_works.svg",
-]
+exclude = ["/test_files"]
 rust-version = "1.62"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -57,9 +51,9 @@ decode-all = [
 encode-wav = ["creek-encode-wav"]
 
 [dependencies]
-creek-core = { version = "0.1", path = "core" }
-creek-decode-symphonia = { version = "0.2.0", path = "decode_symphonia", optional = true }
-creek-encode-wav = { version = "0.1.0", path = "encode_wav", optional = true }
+creek-core = { version = "0.1.1", path = "core" }
+creek-decode-symphonia = { version = "0.2.1", path = "decode_symphonia", optional = true }
+creek-encode-wav = { version = "0.1.1", path = "encode_wav", optional = true }
 
 # Unoptimized builds result in prominent gaps of silence after cache misses in the demo player.
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -4,38 +4,31 @@
 [![Crates.io](https://img.shields.io/crates/v/creek.svg)](https://crates.io/crates/creek)
 [![License](https://img.shields.io/crates/l/creek.svg)](https://github.com/RustyDAW/creek/blob/main/COPYRIGHT)
 
-Realtime-safe disk streaming to/from audio files using [Symphonia](https://github.com/pdeljanov/Symphonia) to support a variety of codecs. Refer to [Symphonia's documentation](https://docs.rs/symphonia/latest/symphonia/#support) for supported codecs. Symphonia's Cargo features are exposed with the prefix `decode-`, except `aac` and `isomp4` which creek does not work with yet. For example, to enable MP3 decoding in creek, enable the `decode-mp3` feature.
+Realtime-safe streaming to/from audio files on disk.
+
+The included decoder uses [Symphonia](https://github.com/pdeljanov/Symphonia). Refer to [Symphonia's documentation](https://docs.rs/symphonia/latest/symphonia/#support) for supported codecs. Symphonia's Cargo features are exposed with the prefix `decode-`, except `aac` and `isomp4` which creek does not work with yet. For example, to enable MP3 decoding in creek, enable the `decode-mp3` feature.
+
+The included encoder only supports the WAV format.
 
 ## How the Read Stream Works
 
 ![how it works](how_it_works.svg)
 
-The stream has two types of buffers: a `cache` buffer and `look-ahead` buffer.
+The stream internally has two types of buffers: a `cache` buffer and `look-ahead` buffer.
 
-A `cache` buffer is a user-defined range (of a fixed user-defined number of blocks) starting from any frame in the file. Caches must be loaded before they can be used. The default size for a block is 16384 frames in length.
+A `cache` buffer is a pre-loaded user-defined range of samples in the file.
 
-There are a number of `look-ahead` blocks ahead of the currently used cache block/playhead. These automatically load-in to ensure that data will always be ready even in the worse-case IO latency scenerio. A number of `look-ahead` blocks are added to the end of every `cache` buffer to ensure enough data is always available.
+The stream can have as many `cache` buffers as desired. A common use case for this is to cache the start of a file or loop region for seamless looping. When seeking to a frame in the file, creek searches if there exists a cache that contains that frame. If one exists, then playback can resume immediately without buffering.
 
-The stream can have as many `cache` buffers as desired. When seeking to a frame in the file, the stream searches for a cache that contains that frame. If one does, then it uses it and playback can resume immediately. A common use case is to cache the start of a file or loop region for seamless looping.
+The `look-ahead` buffer is used to automatically load frames ahead of the playhead, ensuring that data will always be ready even in a worse-case IO latency scenario.
 
-If a suitable cache is not found (or the cache is not loaded yet), then the `look-ahead` buffer will need to fill-up before any more data can be read. In this case, you may choose to either continue playback (which will output silence) or to temporarily pause playback.
+If a suitable cache is not found (or the cache is not yet loaded), then the `look-ahead` buffer will need to be filled first before any more data can be read. When that happens, you may choose to either continue playback (which will output silence), or to temporarily pause playback until data is available.
 
-This stream automatically spawns an "IO server" that handles the non-realtime safe operations. This server is automatically closed when the stream is dropped.
+Creek automatically spawns an "IO server" thread that handles the non-realtime operations. This server is automatically closed when the stream is dropped.
 
 ## How the Write Stream Works
 
-The write stream works how you would expect. Once a block is filled with data, it is sent to the IO server to be written. This block is also recycled back to the stream after writing is done.
-
-### Codecs (Encode)
-
-| Codec  | Status                                          | Default |
-| ------ | ----------------------------------------------- | ------- |
-| Wav    | :heavy_check_mark: Uncompressed, no channel map | Yes     |
-| FLAC   | ? Not currently on roadmap                      | No      |
-| MP3    | ? Not currently on roadmap                      | No      |
-| Opus   | ? Not currently on roadmap                      | No      |
-| PCM    | ? Not currently on roadmap                      | No      |
-| Vorbis | ? Not currently on roadmap                      | No      |
+The write stream works how you would expect. Once a block is filled with data, it is sent to the IO server thread to be written. This block is also recycled back to the stream after writing is done.
 
 ## Examples
 
@@ -118,10 +111,10 @@ write_disk_stream.write(
 
 ### Demos
 
-- A basic [`looping demo player`] that plays a single wav file with adjustable loop regions.
+- A basic [`player app`] that plays a single wav file with adjustable loop regions.
 - A basic [`writer app`] that records a tone to a wav file.
 
-[`looping demo player`]: https://github.com/MeadowlarkDAW/creek/tree/main/demos/player
+[`player app`]: https://github.com/MeadowlarkDAW/creek/tree/main/demos/player
 [`writer app`]: https://github.com/MeadowlarkDAW/creek/tree/main/demos/writer
 
 ## Contributing

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek-core"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/core/src/read/mod.rs
+++ b/core/src/read/mod.rs
@@ -57,7 +57,9 @@ pub struct ReadStreamOptions<D: Decoder> {
     ///
     /// `[cache_start, cache_start + (num_cache_blocks * block_size))`
     ///
-    /// If this is 0, then the cache is only used when seeked to exactly `cache_start`.
+    /// If this is `0`, then the cache is only used when seeked to exactly `cache_start`.
+    ///
+    /// This will cause a panic if `num_cache_blocks + num_look_ahead_blocks < 3`.
     pub num_cache_blocks: usize,
 
     /// The maximum number of caches that can be active in this stream. Keep in mind each
@@ -74,6 +76,9 @@ pub struct ReadStreamOptions<D: Decoder> {
     /// case latency scenerio.
     ///
     /// This should be left alone unless you know what you are doing.
+    ///
+    /// This will cause a panic if this is set to `0` or if
+    /// `num_cache_blocks + num_look_ahead_blocks < 3`.
     pub num_look_ahead_blocks: usize,
 
     /// The number of frames in a prefetch block.

--- a/core/src/read/read_stream.rs
+++ b/core/src/read/read_stream.rs
@@ -73,6 +73,7 @@ impl<D: Decoder> ReadDiskStream<D> {
         assert_ne!(stream_opts.block_size, 0);
         assert_ne!(stream_opts.num_look_ahead_blocks, 0);
         assert_ne!(stream_opts.server_msg_channel_size, Some(0));
+        assert!(stream_opts.num_cache_blocks + stream_opts.num_look_ahead_blocks > 2);
 
         // Reserve ample space for the message channels.
         let msg_channel_size = stream_opts.server_msg_channel_size.unwrap_or(

--- a/core/src/write/mod.rs
+++ b/core/src/write/mod.rs
@@ -38,6 +38,8 @@ pub struct WriteStreamOptions<E: Encoder> {
     /// write latency scenerio.
     ///
     /// This should be left alone unless you know what you are doing.
+    ///
+    /// This will cause a panic if set to less than 3.
     pub num_write_blocks: usize,
 
     /// The number of frames in a write block.

--- a/decode_symphonia/Cargo.toml
+++ b/decode_symphonia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek-decode-symphonia"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ repository = "https://github.com/RustyDAW/creek"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-creek-core = { version = "0.1", path = "../core" }
+creek-core = { version = "0.1.1", path = "../core" }
 log = "0.4"
 symphonia = "0.5"
 

--- a/decode_symphonia/src/lib.rs
+++ b/decode_symphonia/src/lib.rs
@@ -7,7 +7,7 @@
 use std::fs::File;
 use std::path::PathBuf;
 
-use symphonia::core::audio::SampleBuffer;
+use symphonia::core::audio::AudioBuffer;
 use symphonia::core::codecs::{CodecParameters, Decoder as SymphDecoder, DecoderOptions};
 use symphonia::core::errors::Error;
 use symphonia::core::formats::{FormatOptions, FormatReader, SeekMode, SeekTo};
@@ -24,16 +24,16 @@ pub struct SymphoniaDecoder {
     reader: Box<dyn FormatReader>,
     decoder: Box<dyn SymphDecoder>,
 
-    smp_buf: SampleBuffer<f32>,
-    curr_smp_buf_i: usize,
+    decode_buffer: AudioBuffer<f32>,
+    decode_buffer_len: usize,
+    curr_decode_buffer_frame: usize,
 
     num_frames: usize,
-    num_channels: usize,
     sample_rate: Option<u32>,
     block_size: usize,
 
-    current_frame: usize,
-    reset_smp_buffer: bool,
+    playhead_frame: usize,
+    reset_decode_buffer: bool,
 }
 
 impl Decoder for SymphoniaDecoder {
@@ -117,13 +117,13 @@ impl Decoder for SymphoniaDecoder {
         let mut channels = params.channels;
 
         // Decode the first packet to get the signal specification.
-        let smp_buf = loop {
+        let (decode_buffer, decode_buffer_len) = loop {
             match decoder.decode(&reader.next_packet()?) {
                 Ok(decoded) => {
                     // Get the buffer spec.
                     let spec = *decoded.spec();
                     if let Some(channels) = channels {
-                        debug_assert_eq!(channels, spec.channels);
+                        assert_eq!(channels, spec.channels);
                     } else {
                         log::debug!(
                             "Assuming {num_channels} channel(s) according to the first decoded packet",
@@ -132,14 +132,11 @@ impl Decoder for SymphoniaDecoder {
                         channels = Some(spec.channels);
                     }
 
-                    // Get the buffer capacity.
-                    let capacity = decoded.capacity() as u64;
+                    let len = decoded.frames();
 
-                    let mut smp_buf = SampleBuffer::<f32>::new(capacity, spec);
+                    let decode_buffer: AudioBuffer<f32> = decoded.make_equivalent();
 
-                    smp_buf.copy_interleaved_ref(decoded);
-
-                    break smp_buf;
+                    break (decode_buffer, len);
                 }
                 Err(Error::DecodeError(err)) => {
                     // Decode errors are not fatal.
@@ -172,16 +169,16 @@ impl Decoder for SymphoniaDecoder {
                 reader,
                 decoder,
 
-                smp_buf,
-                curr_smp_buf_i: 0,
+                decode_buffer,
+                decode_buffer_len,
+                curr_decode_buffer_frame: 0,
 
                 num_frames,
-                num_channels,
                 sample_rate,
                 block_size,
 
-                current_frame: start_frame,
-                reset_smp_buffer: false,
+                playhead_frame: start_frame,
+                reset_decode_buffer: false,
             },
             file_info,
         ))
@@ -190,14 +187,14 @@ impl Decoder for SymphoniaDecoder {
     fn seek(&mut self, frame: usize) -> Result<(), Self::FatalError> {
         if frame >= self.num_frames {
             // Do nothing if out of range.
-            self.current_frame = self.num_frames;
+            self.playhead_frame = self.num_frames;
 
             return Ok(());
         }
 
-        self.current_frame = frame;
+        self.playhead_frame = frame;
 
-        let seconds = self.current_frame as f64 / f64::from(self.sample_rate.unwrap_or(44100));
+        let seconds = self.playhead_frame as f64 / f64::from(self.sample_rate.unwrap_or(44100));
 
         match self.reader.seek(
             SeekMode::Accurate,
@@ -212,8 +209,8 @@ impl Decoder for SymphoniaDecoder {
             }
         }
 
-        self.reset_smp_buffer = true;
-        self.curr_smp_buf_i = 0;
+        self.reset_decode_buffer = true;
+        self.curr_decode_buffer_frame = 0;
 
         /*
         let decoder_opts = DecoderOptions {
@@ -233,77 +230,54 @@ impl Decoder for SymphoniaDecoder {
         &mut self,
         data_block: &mut DataBlock<Self::T>,
     ) -> Result<(), Self::FatalError> {
-        if self.current_frame >= self.num_frames {
+        if self.playhead_frame >= self.num_frames {
             // Do nothing if reached the end of the file.
             return Ok(());
         }
 
         let mut reached_end_of_file = false;
 
-        let mut block_start = 0;
-        while block_start < self.block_size {
-            let num_frames_to_cpy = if self.reset_smp_buffer {
+        let mut block_start_frame = 0;
+        while block_start_frame < self.block_size {
+            let num_frames_to_cpy = if self.reset_decode_buffer {
                 // Get new data first.
-                self.reset_smp_buffer = false;
-                0
-            } else if self.smp_buf.len() < self.num_channels {
-                // Get new data first.
+                self.reset_decode_buffer = false;
                 0
             } else {
                 // Find the maximum amount of frames that can be copied.
-                (self.block_size - block_start)
-                    .min((self.smp_buf.len() - self.curr_smp_buf_i) / self.num_channels)
+                (self.block_size - block_start_frame)
+                    .min(self.decode_buffer_len - self.curr_decode_buffer_frame)
             };
 
             if num_frames_to_cpy != 0 {
-                if self.num_channels == 1 {
-                    // Mono, no need to deinterleave.
-                    data_block.block[0][block_start..block_start + num_frames_to_cpy]
-                        .copy_from_slice(
-                            &self.smp_buf.samples()
-                                [self.curr_smp_buf_i..self.curr_smp_buf_i + num_frames_to_cpy],
-                        );
-                } else if self.num_channels == 2 {
-                    // Provide efficient stereo deinterleaving.
+                let src_planes = self.decode_buffer.planes();
+                let src_channels = src_planes.planes();
 
-                    let smp_buf = &self.smp_buf.samples()
-                        [self.curr_smp_buf_i..self.curr_smp_buf_i + (num_frames_to_cpy * 2)];
-
-                    let (block1, block2) = data_block.block.split_at_mut(1);
-                    let block1 = &mut block1[0][block_start..block_start + num_frames_to_cpy];
-                    let block2 = &mut block2[0][block_start..block_start + num_frames_to_cpy];
-
-                    for i in 0..num_frames_to_cpy {
-                        block1[i] = smp_buf[i * 2];
-                        block2[i] = smp_buf[i * 2 + 1];
-                    }
-                } else {
-                    let smp_buf = &self.smp_buf.samples()[self.curr_smp_buf_i
-                        ..self.curr_smp_buf_i + (num_frames_to_cpy * self.num_channels)];
-
-                    for i in 0..num_frames_to_cpy {
-                        for (ch, block) in data_block.block.iter_mut().enumerate() {
-                            block[block_start + i] = smp_buf[i * self.num_channels + ch];
-                        }
-                    }
+                for (dst_ch, src_ch) in data_block.block.iter_mut().zip(src_channels) {
+                    let src_ch_part = &src_ch[self.curr_decode_buffer_frame
+                        ..self.curr_decode_buffer_frame + num_frames_to_cpy];
+                    dst_ch[block_start_frame..block_start_frame + num_frames_to_cpy]
+                        .copy_from_slice(src_ch_part);
                 }
 
-                block_start += num_frames_to_cpy;
+                block_start_frame += num_frames_to_cpy;
 
-                self.curr_smp_buf_i += num_frames_to_cpy * self.num_channels;
-                if self.curr_smp_buf_i >= self.smp_buf.len() {
-                    self.reset_smp_buffer = true;
+                self.curr_decode_buffer_frame += num_frames_to_cpy;
+                if self.curr_decode_buffer_frame >= self.decode_buffer_len {
+                    self.reset_decode_buffer = true;
                 }
             } else {
-                // Decode more packets.
+                // Decode the next packet.
 
                 loop {
                     match self.reader.next_packet() {
                         Ok(packet) => {
                             match self.decoder.decode(&packet) {
                                 Ok(decoded) => {
-                                    self.smp_buf.copy_interleaved_ref(decoded);
-                                    self.curr_smp_buf_i = 0;
+                                    self.decode_buffer_len = decoded.frames();
+                                    decoded.convert(&mut self.decode_buffer);
+
+                                    self.curr_decode_buffer_frame = 0;
                                     break;
                                 }
                                 Err(Error::DecodeError(err)) => {
@@ -323,7 +297,7 @@ impl Decoder for SymphoniaDecoder {
                                 if io_error.kind() == std::io::ErrorKind::UnexpectedEof {
                                     // End of file, stop decoding.
                                     reached_end_of_file = true;
-                                    block_start = self.block_size;
+                                    block_start_frame = self.block_size;
                                     break;
                                 } else {
                                     return Err(e);
@@ -338,16 +312,16 @@ impl Decoder for SymphoniaDecoder {
         }
 
         if reached_end_of_file {
-            self.current_frame = self.num_frames;
+            self.playhead_frame = self.num_frames;
         } else {
-            self.current_frame += self.block_size;
+            self.playhead_frame += self.block_size;
         }
 
         Ok(())
     }
 
     fn current_frame(&self) -> usize {
-        self.current_frame
+        self.playhead_frame
     }
 }
 
@@ -474,6 +448,6 @@ mod tests {
             assert_approx_eq!(f32, last_frame[i], samples[i], ulps = 2);
         }
 
-        assert_eq!(decoder.current_frame, file_info.num_frames - 1);
+        assert_eq!(decoder.playhead_frame, file_info.num_frames - 1);
     }
 }

--- a/encode_wav/Cargo.toml
+++ b/encode_wav/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek-encode-wav"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -13,5 +13,5 @@ repository = "https://github.com/RustyDAW/creek"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-creek-core = { version = "0.1", path = "../core" }
+creek-core = { version = "0.1.1", path = "../core" }
 byte-slice-cast = "1.0.0"


### PR DESCRIPTION
Here is some improvements listed in https://github.com/MeadowlarkDAW/creek/pull/37 but without any breaking changes.

* Fixed an issue where the write stream may not write the last remaining samples in the buffer when closed.
* Improved the interleaving performance in the WAV writer.
* Removed the unnecessary interleaving/deinterleaving steps in the Symphonia decoder. Symphonia already has its buffers in deinterleaved form, so removing this should improve performance.
* Added additional asserts to `ReadDiskStream::new()` and `WriteDiskStream::new()`.
* Edited the readme.
* Exclude the test audio files from being included in the crates.io package.