### PR TITLE
improve performance and seek accuracy

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
 
           # Minimum Supported Rust Version (MSRV)
           - os: ubuntu-latest
-            rust: 1.62.0
+            rust: 1.65.0
             workspace-extra-args: "--exclude player --exclude writer"
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improved performance when decoding near the end of a file
 - Improved the accuracy when seeking to a large frame value with the Symphonia decoder
+- Bumped minimum supported Rust version to 1.65
 
 ## Version 1.2.0 (2023-12-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version History
 
+## Version 1.2.1 (2024-1-3)
+
+- Improved performance when decoding near the end of a file
+- Improved the accuracy when seeking to a large frame value with the Symphonia decoder
+
 ## Version 1.2.0 (2023-12-28)
 
 ### Breaking changes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = [
     "LICENSE-MIT",
     "how_it_works.svg",
 ]
-rust-version = "1.62"
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -57,8 +57,8 @@ decode-all = [
 encode-wav = ["creek-encode-wav"]
 
 [dependencies]
-creek-core = { version = "0.2.0", path = "core" }
-creek-decode-symphonia = { version = "0.3.0", path = "decode_symphonia", optional = true }
+creek-core = { version = "0.2.1", path = "core" }
+creek-decode-symphonia = { version = "0.3.1", path = "decode_symphonia", optional = true }
 creek-encode-wav = { version = "0.2.0", path = "encode_wav", optional = true }
 
 # Unoptimized builds result in prominent gaps of silence after cache misses in the demo player.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek-core"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/core/src/read/data.rs
+++ b/core/src/read/data.rs
@@ -17,15 +17,6 @@ impl<T: Copy + Clone + Default + Send> DataBlock<T> {
             ch.clear();
         }
     }
-
-    pub(crate) fn ensure_correct_size(&mut self, block_size: usize) {
-        // If the decoder didn't fill enough frames, then fill the rest with zeros.
-        for ch in self.block.iter_mut() {
-            if ch.len() < block_size {
-                ch.resize(block_size, Default::default());
-            }
-        }
-    }
 }
 
 pub(crate) struct DataBlockCache<T: Copy + Clone + Default + Send> {

--- a/core/src/read/read_stream.rs
+++ b/core/src/read/read_stream.rs
@@ -910,7 +910,7 @@ fn copy_block_into_read_buffer<T: Copy + Default + Send>(
         }
     };
 
-    let Some(block) = maybe_block else {
+    if maybe_block.is_none() {
         // If no block exists, output silence.
         for buffer_ch in heap.read_buffer.block.iter_mut() {
             buffer_ch.resize(buffer_ch.len() + frames, Default::default());
@@ -918,6 +918,8 @@ fn copy_block_into_read_buffer<T: Copy + Default + Send>(
 
         return;
     };
+
+    let block = maybe_block.unwrap();
 
     for (buffer_ch, block_ch) in heap.read_buffer.block.iter_mut().zip(block.block.iter()) {
         // If for some reason the decoder did not fill this block fully,

--- a/core/src/read/read_stream.rs
+++ b/core/src/read/read_stream.rs
@@ -910,7 +910,7 @@ fn copy_block_into_read_buffer<T: Copy + Default + Send>(
         }
     };
 
-    if maybe_block.is_none() {
+    let Some(block) = maybe_block else {
         // If no block exists, output silence.
         for buffer_ch in heap.read_buffer.block.iter_mut() {
             buffer_ch.resize(buffer_ch.len() + frames, Default::default());
@@ -918,8 +918,6 @@ fn copy_block_into_read_buffer<T: Copy + Default + Send>(
 
         return;
     };
-
-    let block = maybe_block.unwrap();
 
     for (buffer_ch, block_ch) in heap.read_buffer.block.iter_mut().zip(block.block.iter()) {
         // If for some reason the decoder did not fill this block fully,

--- a/core/src/read/server.rs
+++ b/core/src/read/server.rs
@@ -113,8 +113,6 @@ impl<D: Decoder> ReadServer<D> {
 
                         let decode_res = self.decoder.decode(&mut block);
 
-                        block.ensure_correct_size(self.block_size);
-
                         match decode_res {
                             Ok(()) => {
                                 self.send_msg(ServerToClientMsg::ReadIntoBlockRes {
@@ -186,8 +184,6 @@ impl<D: Decoder> ReadServer<D> {
                     block.clear();
 
                     let decode_res = self.decoder.decode(block);
-
-                    block.ensure_correct_size(self.block_size);
 
                     if let Err(e) = decode_res {
                         self.send_msg(ServerToClientMsg::FatalError(e));

--- a/decode_symphonia/Cargo.toml
+++ b/decode_symphonia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creek-decode-symphonia"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Billy Messenger <BillyDM@tutamail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ repository = "https://github.com/RustyDAW/creek"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-creek-core = { version = "0.2.0", path = "../core" }
+creek-core = { version = "0.2.1", path = "../core" }
 log = "0.4"
 symphonia = "0.5"
 

--- a/encode_wav/Cargo.toml
+++ b/encode_wav/Cargo.toml
@@ -13,5 +13,5 @@ repository = "https://github.com/RustyDAW/creek"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-creek-core = { version = "0.2.0", path = "../core" }
+creek-core = { version = "0.2.1", path = "../core" }
 byte-slice-cast = "1.0.0"


### PR DESCRIPTION
I discovered that the new safe code could perform worse when decoding near the end of a file. It would zero-out blocks even if those blocks contained no data. So I fixed that.

Since fixing this required a change inside `ReadDiskStream::read()`, I also went ahead and cleaned up that method by consolidating redundant code into a closure.

---

I also noticed that the seeking accuracy in the Symphonia decoder could be improved, so I also did that. Ideally Symphonia should have a method to request an exact frame to seek to, but for now this should be better.

Note this change does not fix https://github.com/MeadowlarkDAW/creek/issues/43. I plan to look into that in a different PR.

Also another side note, I noticed that for some reason I used `usize` for the value of frames instead of `u64`. The whole point of disk streaming is to support very long files, and `usize` would potentially be too limiting on 32 bit platforms. But changing this would be a breaking change, so I'll wait to fix that in a different PR.